### PR TITLE
Work around Nextflow issue with $PWD and Singularity

### DIFF
--- a/config/nf/singularity.config
+++ b/config/nf/singularity.config
@@ -1,6 +1,6 @@
 singularity.enabled    = true
 singularity.autoMounts = true
-singularity.runOptions = '-C'
+singularity.runOptions = '-C -H "$PWD"'
 
 params.contPfx = 'docker://'
 


### PR DESCRIPTION
A recent Nextflow change to how container entrypoints are managed is incompatible with adding -C to singularity.runOptions. Explicitly telling singularity to use the current working directory as the home directory inside the container fixes this.